### PR TITLE
Don't optimize debug builds

### DIFF
--- a/GRBL-Plotter/GRBL-Plotter.csproj
+++ b/GRBL-Plotter/GRBL-Plotter.csproj
@@ -38,7 +38,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Enabling optimisation of debug builds results in a broken debugging experience.

Release builds are still optimized.