### PR TITLE
Speed up merge and sort

### DIFF
--- a/GRBL-Plotter/GCodeCreation/GraphicClasses.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicClasses.cs
@@ -27,6 +27,7 @@
  * 2022-04-23 add OptionSpecialWireBend
  * 2022-11-03 add OptionDashPattern to control ConvertArcToLine
  * 2023-05-31 add OptionSFromWidth
+ * 2023-08-14 modify IsSameAs for speed
 */
 
 using System;
@@ -385,13 +386,17 @@ namespace GrblPlotter
                     if (AuxInfo != tmp.AuxInfo) return false;
                     if (PathGeometry != tmp.PathGeometry) return false;
                     //				if (pathComment != tmp.pathComment)	return false;
-                    if (GroupAttributes.SequenceEqual(tmp.GroupAttributes))
+
+                    for (int i = 1; i < GroupAttributes.Count; i++)    // GroupOptions { none = 0, ByColor = 1, ByWidth = 2, ByLayer = 3, ByType = 4, ByTile = 5};
                     {
-                    //    Logger.Trace("IsSameAs true"); 
-                        return true;
+                        //if (logDetailed) Logger.Trace("  hasSameProperties - GroupEnable-Option:{0} a:'{1}'  b:'{2}'", i, a.Info.GroupAttributes[i], b.Info.GroupAttributes[i]);
+                        if (GroupAttributes[i] != tmp.GroupAttributes[i])
+                            return false;
                     }
+                    //Logger.Trace("IsSameAs true"); 
+                    return true;
                 }
-             //   Logger.Trace("IsSameAs false");
+                //Logger.Trace("IsSameAs false");
                 return false;
             }
             public bool SetGroupAttribute(int index, string txt)

--- a/GRBL-Plotter/GCodeCreation/GraphicCollectData.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicCollectData.cs
@@ -52,6 +52,7 @@
  * 2023-05-31 l:454 f:GetActualZ add OptionSFromWidth
  * 2023-07-02 l:296 f:StartPath ->  actualPath = new ItemPath(xy, GetActualZ());  
  * 2023-08-06 l:830 f:CreateGCode set SortByDistance start-pos to maxy
+ * 2023-08-14 upadte StartPath to be compatible with speed up of HasSameProperties
 */
 
 using System;
@@ -268,7 +269,7 @@ namespace GrblPlotter
             actualPath.Info.CopyData(actualPathInfo);                       // preset global info for GROUP
 
             // only continue last path if same layer, color, dash-pattern - if enabled
-            if ((lastPath is ItemPath apath) && (objectCount > 0) && HasSameProperties(apath, (ItemPath)actualPath) && (IsEqual(xy, lastPoint)))
+            if ((lastPath is ItemPath apath) && (objectCount > 0) && HasSameProperties(apath, (ItemPath)actualPath, Properties.Settings.Default.importLineDashPattern) && (IsEqual(xy, lastPoint)))
             {
                 actualPath = apath;             // only continoue last path if it was finished
                 actualPath.Options = lastOption;

--- a/GRBL-Plotter/GCodeCreation/GraphicCollectData.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicCollectData.cs
@@ -53,6 +53,7 @@
  * 2023-07-02 l:296 f:StartPath ->  actualPath = new ItemPath(xy, GetActualZ());  
  * 2023-08-06 l:830 f:CreateGCode set SortByDistance start-pos to maxy
  * 2023-08-14 upadte StartPath to be compatible with speed up of HasSameProperties
+ * 2023-08-14 improve the UpdateGUI method as it was updating many times in 250 ms
 */
 
 using System;
@@ -152,20 +153,15 @@ namespace GrblPlotter
         { return countGeometry; }
 
 
-        private static bool updateMarker = false;
+        private static int lastUpdateMilliseconds = 0; 
         private static bool UpdateGUI()
         {
-            bool time = ((stopwatch.Elapsed.Milliseconds % 500) > 250);
-            if (time)
+            int elapsed = stopwatch.Elapsed.Milliseconds - lastUpdateMilliseconds;
+            if ((elapsed < 0) || (elapsed > 500))
             {
-                if (updateMarker)
-                {
-                    updateMarker = false;
-                    return true;
-                }
+                lastUpdateMilliseconds = stopwatch.Elapsed.Milliseconds;
+                return true;
             }
-            else
-            { updateMarker = true; }
             return false;
         }
         #endregion

--- a/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
@@ -1304,6 +1304,8 @@ namespace GrblPlotter
 
             while ((graphicToSort.Count > 0) && (!cancelByWorker))                      // items will be removed step by step from completeGraphic
             {
+                double minDist = double.MaxValue;
+                int minDistIndex = -1;
                 for (int i = 0; i < graphicToSort.Count; i++)     // calculate distance to all remaining items check start and end position
                 {
                     tmp = graphicToSort[i];
@@ -1362,13 +1364,21 @@ namespace GrblPlotter
                         }
                         graphicToSort[i] = tmp;
                     }
-                }
-                graphicToSort.Sort((x, y) => x.Distance.CompareTo(y.Distance));   // sort by distance
 
-                sortedGraphic.Add(graphicToSort[0]);       	// get closest item = first in list
-                actualPos = graphicToSort[0].End;         	// set new start pos
-                if (logSortMerge) Logger.Trace("   remove id:{0} ", graphicToSort[0].Info.Id);
-                graphicToSort.RemoveAt(0);                  // remove item from remaining list
+                    if (tmp.Distance < minDist)
+                    {
+                        minDist = tmp.Distance;
+                        minDistIndex = i;
+                    }
+                }
+
+                if (minDistIndex != -1)
+                {
+                    sortedGraphic.Add(graphicToSort[minDistIndex]);       	// get closest item = first in list
+                    actualPos = graphicToSort[minDistIndex].End;         	// set new start pos
+                	if (logSortMerge) Logger.Trace("   remove id:{0} ", graphicToSort[0].Info.Id);
+                    graphicToSort.RemoveAt(minDistIndex);                  // remove item from remaining list
+                }
             }
 
             if (cancelByWorker)//stopwatch.Elapsed.Minutes >= maxTimeMinute)  // time expired, just copy missing figures

--- a/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
@@ -31,6 +31,7 @@
  * 2023-08-06 l:1283 f:SortByDistance get also start-pos
  * 2023-08-14 update SortByDistance to remove the slow sort
  * 2023-08-14 update HasSameProperties for speed
+ * 2023-08-14 reduce the updating of progress bar in SortByDistance
 */
 
 using System;
@@ -1306,23 +1307,23 @@ namespace GrblPlotter
 
             while ((graphicToSort.Count > 0) && (!cancelByWorker))                      // items will be removed step by step from completeGraphic
             {
+                if (backgroundWorker != null)
+                {
+                    if (UpdateGUI()) backgroundWorker.ReportProgress(((maxElements - graphicToSort.Count) * 100) / maxElements);
+                    if (backgroundWorker.CancellationPending)
+                    {
+                        cancelByWorker = true;
+                        backgroundWorker.ReportProgress(100, new MyUserState { Value = 100, Content = "Stop processing, clean up data. Please wait!" });
+                        break;
+                    }
+                }
+
                 double minDist = double.MaxValue;
                 int minDistIndex = -1;
                 for (int i = 0; i < graphicToSort.Count; i++)     // calculate distance to all remaining items check start and end position
                 {
                     tmp = graphicToSort[i];
                     tmp.Distance = PointDistanceSquared(actualPos, tmp.Start);
-
-                    if (backgroundWorker != null)
-                    {
-                        if (UpdateGUI()) backgroundWorker.ReportProgress(((maxElements - graphicToSort.Count) * 100) / maxElements);
-                        if (backgroundWorker.CancellationPending)
-                        {
-                            cancelByWorker = true;
-                            backgroundWorker.ReportProgress(100, new MyUserState { Value = 100, Content = "Stop processing, clean up data. Please wait!" });
-                            break;
-                        }
-                    }
 
                     if (tmp is ItemPath tmpItemPath)
                     {

--- a/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
@@ -1368,6 +1368,7 @@ namespace GrblPlotter
                         graphicToSort[i] = tmp;
                     }
 
+                    // Keep index of the item with the shortest distance
                     if (tmp.Distance < minDist)
                     {
                         minDist = tmp.Distance;
@@ -1375,11 +1376,12 @@ namespace GrblPlotter
                     }
                 }
 
+                // Move the item with the shortest distance to the sorted list
                 if (minDistIndex != -1)
                 {
                     sortedGraphic.Add(graphicToSort[minDistIndex]);       	// get closest item = first in list
                     actualPos = graphicToSort[minDistIndex].End;         	// set new start pos
-                	if (logSortMerge) Logger.Trace("   remove id:{0} ", graphicToSort[0].Info.Id);
+                	if (logSortMerge) Logger.Trace("   remove id:{0} ", graphicToSort[minDistIndex].Info.Id);
                     graphicToSort.RemoveAt(minDistIndex);                  // remove item from remaining list
                 }
             }

--- a/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
+++ b/GRBL-Plotter/GCodeCreation/GraphicGenerateMisc.cs
@@ -29,6 +29,8 @@
  * 2023-07-13 l:800 f:RemoveShortMoves also compare depth informnation
  * 2023-07-30 l:898 f:RemoveOffset calc new dimesnion for all types
  * 2023-08-06 l:1283 f:SortByDistance get also start-pos
+ * 2023-08-14 update SortByDistance to remove the slow sort
+ * 2023-08-14 update HasSameProperties for speed
 */
 
 using System;
@@ -1478,17 +1480,15 @@ namespace GrblPlotter
         private static Point ToPointF(XyPoint tmp)
         { return new Point((float)tmp.X, (float)tmp.Y); }
 
-        private static bool HasSameProperties(ItemPath a, ItemPath b)
+        private static bool HasSameProperties(ItemPath a, ItemPath b, bool importLineDashPattern)
         {
-            bool sameProperties = true;
             //            bool checkAll = false;// true;
             if (graphicInformation.GroupEnable)
             {
-                for (int i = 1; i <= 6; i++)    // GroupOptions { none = 0, ByColor = 1, ByWidth = 2, ByLayer = 3, ByType = 4, ByTile = 5, ByFill = 6, Label = 7};
+                for (int i = 1; i < a.Info.GroupAttributes.Count; i++)    // GroupOptions { none = 0, ByColor = 1, ByWidth = 2, ByLayer = 3, ByType = 4, ByTile = 5};
                 {
                     if (logDetailed) Logger.Trace("  hasSameProperties - GroupEnable-Option:{0} a:'{1}'  b:'{2}'", i, a.Info.GroupAttributes[i], b.Info.GroupAttributes[i]);
-                    sameProperties = a.Info.GroupAttributes[i] == b.Info.GroupAttributes[i];
-                    if (!sameProperties)
+                    if (a.Info.GroupAttributes[i] != b.Info.GroupAttributes[i])
                         return false;
                 }
             }
@@ -1499,17 +1499,24 @@ namespace GrblPlotter
                         return false;
                 }*/
 
-            bool sameDash = true;
-            if (Properties.Settings.Default.importLineDashPattern)
+            if (importLineDashPattern)
             {
-                //                Logger.Trace("  hasSameProperties a-count:{0} dash-a:{1}  b-count:{2} dash-b:{3}", a.dashArray.Count(), showArray(a.dashArray), b.dashArray.Count(), showArray(b.dashArray));
-                sameDash = false;
                 if ((a.DashArray.Length == 0) && (b.DashArray.Length == 0))
-                    sameDash = true;
-                else if (a.DashArray == b.DashArray)
-                    sameDash = true;
+                {
+                    return true;
+                }
+                else
+                {
+                    if (a.DashArray.Length != b.DashArray.Length)
+                        return false;
+                    for (int i = 1; i <= a.DashArray.Length; i++)
+                    {
+                        if (a.DashArray[i] != b.DashArray[i])
+                            return false;
+                    }
+                }
             }
-            return (sameProperties && sameDash);
+            return true;
         }
         /*     private static string ShowArray(double[] tmp)
              {   string tmps = "";
@@ -1525,6 +1532,7 @@ namespace GrblPlotter
 
             int i, k;
             int maxElements = graphicToMerge.Count;
+            bool importLineDashPattern = Properties.Settings.Default.importLineDashPattern; // Keep a local copy for speed
 
             for (i = graphicToMerge.Count - 1; i > 0; i--)
             {
@@ -1565,7 +1573,7 @@ namespace GrblPlotter
                                 continue;
 
                             // paths with different propertys should not be merged
-                            if (!HasSameProperties(ipath, kpath))
+                            if (!HasSameProperties(ipath, kpath, importLineDashPattern))
                             {   //                             Logger.Trace("  not same Properties");
                                 continue;
                             }


### PR DESCRIPTION
This is a solution for issue #347 

Surprisingly the most important change is to not access Properties.Settings.Default.importLineDashPattern thousands of times.  The settings are stored in a list indexed by a string.

I have put the change into 3 separate commits that cover different aspects of the fix, so that you can decide which (if any) you want to include.

I have made the sorting work much faster by storing the index to the item with the shortest distance removing the need for a sort.

I improved the compare of properties, but the big factor here was not checking Properties.Settings.Default.importLineDashPattern more than necessary.

I have made the updating of the progress bar use less CPU.  I don't think the function that decided if half a second had elapsed was working quite how you intended.

In your master branch there is currently an error that prevents it compiling.  GCodeFromTeext.cs accesses Graphic.graphicInformation.OptionSortCode which doesn't exist.  I deleted the line locally to perform my tests, but haven't checked in the change.

Timings before were 24min16 and are now 1min47

